### PR TITLE
add android password store

### DIFF
--- a/github-android.yaml
+++ b/github-android.yaml
@@ -1746,3 +1746,10 @@ dantotsu:
     repository: https://github.com/rebelonion/Dantotsu
     artifacts:
       - app-release.apk
+
+passwordstore:
+  android:
+    name: Android Password Store
+    repository: https://github.com/agrahn/Android-Password-Store
+    artifacts:
+      - APS-free_v%v.apk 


### PR DESCRIPTION
Add android password store, a porting of the unix password store based on pgp and git