### PR TITLE
passwordstore: revert last changes, name convention changed

### DIFF
--- a/github-android.yaml
+++ b/github-android.yaml
@@ -1752,7 +1752,7 @@ passwordstore:
     name: Android Password Store
     repository: https://github.com/agrahn/Android-Password-Store
     artifacts:
-      - APS-freeRelease-%v.apk 
+      - APS-free_v%v.apk
 
 mistybreez:
   android:


### PR DESCRIPTION
Hi, the app dev has changed the name of the apk, I think cause this is the first release and he is adjusting his script-release.  This PR revert the name convenction to the actual one he is eneded using for his app.